### PR TITLE
Update pt.po

### DIFF
--- a/translations/pt.po
+++ b/translations/pt.po
@@ -29,7 +29,7 @@ msgstr "O relatório do sistema foi exportado para o ambiente de trabalho."
 
 #: MainWindow.glade:62
 msgid "~/Desktop/pardus_system_report.tar.gz"
-msgstr "~/Área de Trabalho/pardus_system_report.tar.gz"
+msgstr "~/Transferências/pardus_system_report.tar.gz"
 
 #: MainWindow.glade:91
 msgid "About this computer"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -29,7 +29,7 @@ msgstr "O relatório do sistema foi exportado para o ambiente de trabalho."
 
 #: MainWindow.glade:62
 msgid "~/Desktop/pardus_system_report.tar.gz"
-msgstr "~/Desktop/pardus_system_report.tar.gz"
+msgstr "~/Área de Trabalho/pardus_system_report.tar.gz"
 
 #: MainWindow.glade:91
 msgid "About this computer"


### PR DESCRIPTION
Change the destination of the system report archive, since "Desktop" translation in Portuguese is ambiguous in Thunar and Nautilus file managers and therefore the archive was not exported properly!
Changed the destination to ~/Downloads("Transferências" in Portuguese) folder.